### PR TITLE
Added possibility to also use session credentials for AWStealth Scan

### DIFF
--- a/AWStealth/AWStealth.ps1
+++ b/AWStealth/AWStealth.ps1
@@ -147,8 +147,14 @@ function Load-AWScred {
         $DefaultRegion = read-host "What is your AWS default region (e.g. `"us-east-1`")?"
     }
     Set-DefaultAWSRegion -Region $DefaultRegion
-    $currentUser = Get-IAMUser
-    $currentUserName = $currentUser.UserName
+    if ($SessionToken) {
+        $currentUser = Get-STSCallerIdentity
+        $currentUserName = $currentUser.Arn
+    }
+    else {
+        $currentUser = Get-IAMUser
+        $currentUserName = $currentUser.UserName
+    }
     Write-Host "`n[+] Loaded AWS credentials - $tempProfile [EntityName=$currentUserName]"
 }
 

--- a/AWStealth/AWStealth.ps1
+++ b/AWStealth/AWStealth.ps1
@@ -130,7 +130,17 @@ function Load-AWScred {
         if (-not $SecretKey) {
             $SecretKey = read-host "What is the AWS SecretKey?"
         }
-        Set-AWSCredential -AccessKey $AccessKeyID -SecretKey $SecretKey -StoreAs $tempProfile
+        if (-not $SessionToken) {
+            $SessionToken = read-host "What is the AWS SessionToken (hit Enter if none)?"
+        }
+        if ($SessionToken) {
+            "SessionToken set"
+            Set-AWSCredential -AccessKey $AccessKeyID -SecretKey $SecretKey -SessionToken $SessionToken -StoreAs $tempProfile
+        }
+        else {
+            "SessionToken not set"
+            Set-AWSCredential -AccessKey $AccessKeyID -SecretKey $SecretKey -StoreAs $tempProfile
+        }
         Set-AWSCredential -ProfileName $tempProfile
     }
     if (-not $DefaultRegion) {


### PR DESCRIPTION
Hi Hechtov!
This change is useful for example for federated AWS environments, where you only can assume roles via sts after login. If you use the script as is, you get an error about an invalid session token.
I tested both cases (login user/sts session) locally, both worked for me.
Thanks for this script! Very helpful