### PR TITLE
Add paramaters to pull all RBAC roles to Run-SubscriptionScan and Sca…

### DIFF
--- a/AzureStealth/AzureStealth.ps1
+++ b/AzureStealth/AzureStealth.ps1
@@ -25,6 +25,7 @@ https://github.com/cyberark/SkyArk
 https://github.com/cyberark/SkyArk/tree/master/AzureStealth
 Version 1.1 - 01.09.19 - added two sensitive directory roles
 Version 1.2 - 07.09.20 - add support for CSP suscriptions
+Version 1.3 - 01.07.21 - add support for scanning for all roles and all scopes
 
 ###########################################################################################
 


### PR DESCRIPTION
…n-AzureAdmins. Add Assignment to Azure Privileged Entity Results to for to identify where the Privilege is coming from

### Desired Outcome
Allow for Scanning of All RBAC roles in Azure Subscription and easy identification of group that user is receiving the assignment via.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- What's changed? 
  Run-SubscriptionScan changed to include an -AllRoles Parameter to scan all roles.
This parameter is supported by logic at lines 559 - 565 that grabs all roles.  Original Logic is now in the else case below case.
Scan-AzureAdmins: -AllAzureRBACRoles Parameter added to surface new functionality
 Add-PrivilegeAzureEntity - Added -PrivilegeGroup and -GroupPrivilege PrivilegeGroup refers to the group that has the privilege that user is recieving and GroupPrivilege is switch that exists to tell the cmdlet what to fill in new Assignment field
 Run-SubscriptionScan has been updated so that it use Add-AzurePrivilegedEntity for Groups in the do while loop that processes groups. 

- Why were these changes made?_ To make this script more useful for auditing permissions and resolving.
- _How should the reviewer approach this PR, especially if manual tests are required?_
- Scan-AzureAdmins -ScanAllAzureRBACRoles to expose all roles
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
