### PR TITLE
[README] Correct AWStealth reference to AWS shadow admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In short:
  ![Demo](https://github.com/Hechtov/Photos/blob/master/SkyArk/AzureStealth%20-%20short%20demo1.gif?raw=true)  
    
   ### 2. AWStealth Scan
-**Discover the most privileged entities in the scanned AWS environment - including the Azure Shadow Admins.**
+**Discover the most privileged entities in the scanned AWS environment - including the AWS Shadow Admins.**
   
 **How To Run AWStealth**  
 The full details are in the AWStealth's Readme file:  


### PR DESCRIPTION
### Desired Outcome

Under the `AWStealth Scan` README header, it had `including the Azure Shadow Admins` instead of `including the AWS Shadow Admins`

P.S. Thanks for this awesome tool! Just a nit I found while reading the README that threw me off.

### Implemented Changes
Changed `Azure Shadow Admins` to `AWS Shadow Admins`

### Connected Issue/Story

Resolves #18

### Definition of Done
- [x] The wording has been properly updated

#### Changelog
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation

#### Behavior
- [x] No behavior was changed with this PR

#### Security
- [x] There are no security aspects to these changes 
